### PR TITLE
Ensure concurrent dind images won't use same CGROUP_PARENT

### DIFF
--- a/dind/entrypoint.sh
+++ b/dind/entrypoint.sh
@@ -37,9 +37,9 @@ if [ -f /sys/fs/cgroup/systemd/release_agent ]; then
   # pollute the host cgroups hierarchy.
   # Note that `release_agent` file is only created at the root of a
   # cgroup hierarchy.
-  CGROUP_PARENT="$(grep systemd /proc/self/cgroup | cut -d: -f3)/docker"
+  CGROUP_PARENT="$(grep systemd /proc/self/cgroup | cut -d: -f3)/docker-${HOSTNAME}"
 else
-  CGROUP_PARENT="/docker"
+  CGROUP_PARENT="/docker-${HOSTNAME}"
 
   # For each cgroup subsystem, Docker does a bind mount from the
   # current cgroup to the root of the cgroup subsystem. For instance:


### PR DESCRIPTION
I just checked the code and thought about this.

But I don't actually understand deeply how this works so I thought I could send this PR to raise this point.

Is it a good thing to do?